### PR TITLE
Allow custom metadata types

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -3131,7 +3131,7 @@ function acf_get_post_id_info( $post_id = 0 ) {
 		$type = explode($glue, $post_id);
 		$id = array_pop($type);
 		$type = implode($glue, $type);
-		$meta = array('post', 'user', 'comment', 'term');
+		$meta = apply_filters('acf/metadata_type/', array('post', 'user', 'comment', 'term'));
 		
 		
 		// check if is taxonomy (ACF < 5.5)


### PR DESCRIPTION
I would like to be able to customise what metadata table my metadata is stored in for different post types. It will be much easier to do if this change is made.

The reason for this is because my postmeta table has become very large and slow. This will allow me to split up the data into different tables.