### PR TITLE
Fix the import form not working

### DIFF
--- a/includes/admin/admin-tools.php
+++ b/includes/admin/admin-tools.php
@@ -275,7 +275,7 @@ class acf_admin_tools {
 		
 		
 		?>
-		<form method="post">
+		<form method="post" enctype="multipart/form-data">
 			<?php $tool->html(); ?>
 			<?php acf_nonce_input( $tool->name ); ?>
 		</form>


### PR DESCRIPTION
When I tried to import a file, it says "No file selected". As I debugged and found that the form tag doesn't have the enctype attribute which requires to file handling.